### PR TITLE
Update README.md to include required mysql-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ PlanetScale is more than a database and our CLI is more than a jumble of command
 ```
 brew install planetscale/tap/pscale
 ```
+!! Note of importance: `pscale` requires the MySQL Client. You can install it by running:
+
+```
+brew install mysql-client
+```
 
 To upgrade to the latest version:
 


### PR DESCRIPTION
Upon invoking the `pscale` cli, an error occurs stating:
`Error: couldn't find the 'msyql' client required to run this command.`
To resolve this, you need to run:
`brew install mysql-client`

